### PR TITLE
Adjust tasklist offset slightly

### DIFF
--- a/src/main/java/com/logmaster/ui/component/TaskList.java
+++ b/src/main/java/com/logmaster/ui/component/TaskList.java
@@ -28,7 +28,7 @@ import static com.logmaster.ui.InterfaceConstants.*;
 @Slf4j
 public class TaskList extends UIPage {
     private final int OFFSET_X = 0;
-    private final int OFFSET_Y = 22;
+    private final int OFFSET_Y = 21;
     private final int TASK_WIDTH = 300;
     private final int TASK_HEIGHT = 50;
     private final int COLUMN_SPACING = 24;


### PR DESCRIPTION
Adjusting offset slightly so 5 task fit in the default view size:
Currently windows unable to be resized and only 4 tasks are visible, with this change, should show 5
<img width="751" height="468" alt="image" src="https://github.com/user-attachments/assets/f6ab3142-74ff-4bac-9a06-037006d6f6a7" />