### PR TITLE
Add reroll function

### DIFF
--- a/src/main/java/com/logmaster/LogMasterConfig.java
+++ b/src/main/java/com/logmaster/LogMasterConfig.java
@@ -105,4 +105,23 @@ public interface LogMasterConfig extends Config
     {
         return true;
     }
+
+    @ConfigSection(
+            name = "Unofficial taskman config",
+            description = "Configuration options for unofficial taskman",
+            position = 20
+    )
+    String unofficial = "unofficial";
+
+    @ConfigItem(
+            keyName = "rerolls",
+            name = "Enable rerolls",
+            description = "0 to disable. Set this to the amount of rerolls you want to allow. Changes apply after completing your current task.",
+            section = unofficial,
+            position = 1
+    )
+    default int rerollsAllowed()
+    {
+        return 0;
+    }
 }

--- a/src/main/java/com/logmaster/domain/savedata/SaveData.java
+++ b/src/main/java/com/logmaster/domain/savedata/SaveData.java
@@ -22,4 +22,7 @@ public class SaveData extends BaseSaveData {
 
     @Setter
     private @Nullable Task activeTask = null;
+
+    @Setter
+    private int rerolls = 0;
 }

--- a/src/main/java/com/logmaster/ui/component/TaskDashboard.java
+++ b/src/main/java/com/logmaster/ui/component/TaskDashboard.java
@@ -180,6 +180,9 @@ public class TaskDashboard extends UIPage {
 
     public void setTask(Task task, List<Task> cyclingTasks) {
         this.disableGenerateTask();
+        this.disableCompleteTask();
+        this.taskBg.getWidget().clearActions();
+        this.taskBg.clearActions();
 
         if (cyclingTasks != null) {
             for (int i = 0; i < 250; i++) {
@@ -207,6 +210,10 @@ public class TaskDashboard extends UIPage {
         this.taskLabel.setText(task.getName());
         this.taskImage.setItem(task.getDisplayItemId());
         this.taskBg.addAction("View task info", () -> taskInfo.showTask(task.getId()));
+        
+        if (taskService.getRerolls() > 0) {
+            this.enableGenerateTask();
+        }
         this.enableCompleteTask();
         this.enableFaqButton();
     }
@@ -216,9 +223,10 @@ public class TaskDashboard extends UIPage {
 		Task generatedTask = taskService.generate();
 
 		List<Task> rollTaskList = config.rollPastCompleted() ? taskService.getTierTasks() : taskService.getIncompleteTierTasks();
-		setTask(generatedTask, rollTaskList);
         disableGenerateTask();
+        disableCompleteTask();
         updatePercentages();
+		setTask(generatedTask, rollTaskList);
 	}
 
     public void updatePercentages() {
@@ -260,13 +268,20 @@ public class TaskDashboard extends UIPage {
         this.generateTaskBtn.setSprites(GENERATE_TASK_DISABLED_SPRITE_ID);
         this.generateTaskBtn.clearActions();
 
+        this.generateTaskBtn.setName("");
         this.generateTaskBtn.addAction("Disabled", this::playFailSound);
     }
 
     public void enableGenerateTask() {
         this.generateTaskBtn.clearActions();
         this.generateTaskBtn.setSprites(GENERATE_TASK_SPRITE_ID, GENERATE_TASK_HOVER_SPRITE_ID);
-        this.generateTaskBtn.addAction("Generate task", this::generateTask);
+        if (taskService.getRerolls() > 0 && taskService.getActiveTask() != null) {
+            this.generateTaskBtn.setName(taskService.getRerolls() + " remaining");
+            this.generateTaskBtn.addAction("Reroll task", this::generateTask);
+        } else {
+            this.generateTaskBtn.setName("");
+            this.generateTaskBtn.addAction("Generate task", this::generateTask);
+        }
 
         this.disableCompleteTask();
     }


### PR DESCRIPTION
closes #65 

Adds ability to reroll tasks.

Added a new config option:
_by default set to 0_
<img width="241" height="68" alt="image" src="https://github.com/user-attachments/assets/4c426bb3-6ffe-40bb-8fcb-123de6830c2a" />

Will show like this if you have rerolls available:
<img width="746" height="467" alt="image" src="https://github.com/user-attachments/assets/f1ab89b3-f611-4371-9b89-971af42c059d" />

Rerolls are reset to max whenever you complete your currently active task.
Changes to the amount of rerolls you will get only take affect after you complete your current task.